### PR TITLE
Add OpenAI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ python -m linkedin_agent.orchestrator
 ```
 
 The script will prompt for job details, search the sample data, display candidate summaries and show example outreach messages.
+
+### Using an LLM
+
+If you have an OpenAI API key, you can use it to generate more natural summaries and outreach messages. Install the `openai` package and set the `OPENAI_API_KEY` environment variable:
+
+```bash
+pip install openai
+export OPENAI_API_KEY=<your-key>
+python -m linkedin_agent.orchestrator --use-llm
+```
+
+Without the `--use-llm` flag the script falls back to simple rule-based summaries.

--- a/linkedin_agent/agents/candidate_discussion.py
+++ b/linkedin_agent/agents/candidate_discussion.py
@@ -2,6 +2,8 @@
 
 from typing import List
 
+from ..llm import chat_completion
+
 from .candidate_sourcing import Candidate
 from .role_clarification import JobRequirement
 
@@ -9,19 +11,45 @@ from .role_clarification import JobRequirement
 class CandidateDiscussionAgent:
     """Evaluate candidates against job requirements."""
 
-    def evaluate(self, requirements: JobRequirement, candidates: List[Candidate]) -> List[str]:
-        summaries = []
+    def evaluate(
+        self,
+        requirements: JobRequirement,
+        candidates: List[Candidate],
+        *,
+        use_llm: bool = False,
+    ) -> List[str]:
+        summaries: List[str] = []
         for c in candidates:
-            pro_skills = [s for s in c.skills if s in requirements.skills]
-            missing_skills = [s for s in requirements.skills if s not in c.skills]
-            summary = [f"Candidate {c.name}:"]
-            if pro_skills:
-                summary.append(f"  Matches skills: {', '.join(pro_skills)}")
-            if missing_skills:
-                summary.append(f"  Missing skills: {', '.join(missing_skills)}")
-            if requirements.experience_years:
-                summary.append(
-                    f"  Experience: {c.experience_years} years (required {requirements.experience_years})"
+            if use_llm:
+                prompt = (
+                    "Given the following job requirements:\n"
+                    f"Title: {requirements.title}\n"
+                    f"Location: {requirements.location}\n"
+                    f"Skills: {', '.join(requirements.skills)}\n"
+                    f"Experience: {requirements.experience_years}\n\n"
+                    "Summarize how well this candidate fits the role:\n"
+                    f"Name: {c.name}\n"
+                    f"Skills: {', '.join(c.skills)}\n"
+                    f"Experience: {c.experience_years}\n"
                 )
-            summaries.append("\n".join(summary))
+                try:
+                    summary = chat_completion(prompt)
+                except Exception as exc:  # noqa: PERF203
+                    summary = f"LLM error: {exc}"
+            else:
+                pro_skills = [s for s in c.skills if s in requirements.skills]
+                missing_skills = [s for s in requirements.skills if s not in c.skills]
+                summary_parts = [f"Candidate {c.name}:"]
+                if pro_skills:
+                    summary_parts.append(f"  Matches skills: {', '.join(pro_skills)}")
+                if missing_skills:
+                    summary_parts.append(f"  Missing skills: {', '.join(missing_skills)}")
+                if requirements.experience_years:
+                    summary_parts.append(
+                        f"  Experience: {c.experience_years} years (required {requirements.experience_years})"
+                    )
+                summary = "\n".join(summary_parts)
+
+            summaries.append(summary)
+
         return summaries

--- a/linkedin_agent/agents/outreach.py
+++ b/linkedin_agent/agents/outreach.py
@@ -2,13 +2,33 @@
 
 from .candidate_sourcing import Candidate
 from .role_clarification import JobRequirement
+from ..llm import chat_completion
 
 
 class OutreachAgent:
     """Generate basic outreach messages for approved candidates."""
 
-    def draft_message(self, candidate: Candidate, requirements: JobRequirement) -> str:
+    def draft_message(
+        self,
+        candidate: Candidate,
+        requirements: JobRequirement,
+        *,
+        use_llm: bool = False,
+    ) -> str:
         skills = ", ".join(requirements.skills)
+        if use_llm:
+            prompt = (
+                "Write a short and friendly recruiting message.\n"
+                f"Role: {requirements.title}\n"
+                f"Location: {requirements.location}\n"
+                f"Skills required: {skills}\n\n"
+                f"Candidate name: {candidate.name}\n"
+            )
+            try:
+                return chat_completion(prompt)
+            except Exception as exc:  # noqa: PERF203
+                return f"LLM error: {exc}"
+
         return (
             f"Hi {candidate.name},\n"
             f"We're looking for a {requirements.title} skilled in {skills} at our company.\n"

--- a/linkedin_agent/llm.py
+++ b/linkedin_agent/llm.py
@@ -1,0 +1,20 @@
+import os
+from typing import Optional
+
+import openai
+
+
+openai.api_key = os.environ.get("OPENAI_API_KEY")
+
+
+def chat_completion(prompt: str, *, model: str = "gpt-3.5-turbo", max_tokens: int = 150) -> str:
+    """Call OpenAI Chat API and return the assistant message."""
+    if not openai.api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=max_tokens,
+    )
+    return response["choices"][0]["message"]["content"].strip()

--- a/linkedin_agent/orchestrator.py
+++ b/linkedin_agent/orchestrator.py
@@ -1,5 +1,7 @@
 """Simple command-line orchestrator for the recruiter agents."""
 
+import argparse
+
 from .agents.role_clarification import RoleClarificationAgent
 from .agents.candidate_sourcing import CandidateSourcingAgent
 from .agents.candidate_discussion import CandidateDiscussionAgent
@@ -7,6 +9,14 @@ from .agents.outreach import OutreachAgent
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the recruiting assistant")
+    parser.add_argument(
+        "--use-llm",
+        action="store_true",
+        help="Use OpenAI to generate summaries and outreach messages",
+    )
+    args = parser.parse_args()
+
     role_agent = RoleClarificationAgent()
     requirements = role_agent.clarify_requirements()
 
@@ -18,7 +28,7 @@ def main() -> None:
         return
 
     discussion_agent = CandidateDiscussionAgent()
-    summaries = discussion_agent.evaluate(requirements, candidates)
+    summaries = discussion_agent.evaluate(requirements, candidates, use_llm=args.use_llm)
     print("Candidate summaries:")
     for summary in summaries:
         print(summary)
@@ -26,7 +36,7 @@ def main() -> None:
 
     outreach_agent = OutreachAgent()
     for candidate in candidates:
-        msg = outreach_agent.draft_message(candidate, requirements)
+        msg = outreach_agent.draft_message(candidate, requirements, use_llm=args.use_llm)
         print(f"Outreach message for {candidate.name}:")
         print(msg)
         print()


### PR DESCRIPTION
## Summary
- provide OpenAI helper to call ChatCompletion API
- allow candidate summaries and outreach generation via `--use-llm`
- update CLI for the new option
- document how to enable LLM usage

## Testing
- `python -m linkedin_agent.orchestrator --help`
- `python -m linkedin_agent.orchestrator --use-llm <<'EOF'
Data Engineer
NY
Python, Machine Learning
5
EOF`
- `python -m linkedin_agent.orchestrator <<'EOF'
Data Engineer
NY
Python, Machine Learning
5
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686844a04ac083239045ee57f3d33b08